### PR TITLE
Feat: 메인페이지 월간 여행일정 확인 기능 개발

### DIFF
--- a/src/main/java/org/solcation/solcation_be/domain/main/controller/MainController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/main/controller/MainController.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.solcation.solcation_be.common.CustomException;
 import org.solcation.solcation_be.common.ErrorCode;
 import org.solcation.solcation_be.domain.main.dto.GroupShortDTO;
+import org.solcation.solcation_be.domain.main.dto.MonthlyPlanDTO;
 import org.solcation.solcation_be.domain.main.dto.MyPageDTO;
 import org.solcation.solcation_be.domain.main.dto.NotificationPreviewDTO;
 import org.solcation.solcation_be.domain.main.service.GroupShortService;
+import org.solcation.solcation_be.domain.main.service.MonthlyPlanService;
 import org.solcation.solcation_be.domain.main.service.MyPageService;
 import org.solcation.solcation_be.domain.main.service.NotificationPreviewService;
 import org.solcation.solcation_be.entity.User;
@@ -26,6 +28,7 @@ public class MainController {
     private final MyPageService myPageService;
     private final UserRepository userRepository;
     private final NotificationPreviewService notificationPreviewService;
+    private final MonthlyPlanService monthlyPlanService;
 
     @GetMapping("/my-groups")
     public List<GroupShortDTO> getMyGroups(
@@ -58,5 +61,18 @@ public class MainController {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return notificationPreviewService.getNotificationPreview(userPk);
+    }
+
+    @GetMapping("/monthly-plans")
+    public List<MonthlyPlanDTO> getMonthlyPlans(
+            @RequestParam int year,
+            @RequestParam int month,
+            @AuthenticationPrincipal JwtPrincipal principal
+    ) {
+        Long userPk = userRepository.findByUserId(principal.userId())
+                .map(User::getUserPk)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return monthlyPlanService.getMonthlyPlans(userPk, year, month);
     }
 }

--- a/src/main/java/org/solcation/solcation_be/domain/main/dto/MonthlyPlanDTO.java
+++ b/src/main/java/org/solcation/solcation_be/domain/main/dto/MonthlyPlanDTO.java
@@ -1,0 +1,16 @@
+package org.solcation.solcation_be.domain.main.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class MonthlyPlanDTO {
+    private LocalDate tpStart;
+    private LocalDate tpEnd;
+    private String gcIcon;
+    private String tpTitle;
+    private String groupName;
+}

--- a/src/main/java/org/solcation/solcation_be/domain/main/service/MonthlyPlanService.java
+++ b/src/main/java/org/solcation/solcation_be/domain/main/service/MonthlyPlanService.java
@@ -1,0 +1,52 @@
+package org.solcation.solcation_be.domain.main.service;
+
+import lombok.RequiredArgsConstructor;
+import org.solcation.solcation_be.common.CustomException;
+import org.solcation.solcation_be.common.ErrorCode;
+import org.solcation.solcation_be.domain.main.dto.MonthlyPlanDTO;
+import org.solcation.solcation_be.entity.GroupMember;
+import org.solcation.solcation_be.entity.Travel;
+import org.solcation.solcation_be.repository.GroupMemberRepository;
+import org.solcation.solcation_be.repository.TravelRepository;
+import org.solcation.solcation_be.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyPlanService {
+
+    private final UserRepository userRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final TravelRepository travelRepository;
+
+    public List<MonthlyPlanDTO> getMonthlyPlans(Long userPk, int year, int month) {
+        userRepository.findById(userPk)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<GroupMember> memberships = groupMemberRepository
+                .findByUser_UserPkAndIsAcceptedTrueAndIsOutFalse(userPk);
+
+        List<Long> groupPks = memberships.stream()
+                .map(gm -> gm.getGroup().getGroupPk())
+                .toList();
+
+        LocalDate monthStart = LocalDate.of(year, month, 1);
+        LocalDate monthEnd = monthStart.withDayOfMonth(monthStart.lengthOfMonth());
+
+        List<Travel> travels = travelRepository
+                .findAllByGroup_GroupPkInAndTpStartLessThanEqualAndTpEndGreaterThanEqualOrderByTpStartAsc(groupPks, monthEnd, monthStart);
+
+        return travels.stream()
+                .map(t -> MonthlyPlanDTO.builder()
+                        .tpStart(t.getTpStart())
+                        .tpEnd(t.getTpEnd())
+                        .tpTitle(t.getTpTitle())
+                        .groupName(t.getGroup().getGroupName())
+                        .gcIcon(t.getGroup().getGcPk().getGcIcon())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/org/solcation/solcation_be/repository/GroupMemberRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/GroupMemberRepository.java
@@ -9,6 +9,11 @@ import java.util.List;
 @Repository
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
+    // 그룹 pk 기준으로 8개만 찾기
     List<GroupMember> findTop8ByUser_UserPkAndIsAcceptedTrueAndIsOutFalseOrderByGroup_GroupPkDesc(Long userPk);
+
     boolean existsByGroup_GroupPkAndUser_UserPkAndIsAcceptedTrueAndIsOutFalse(Long groupPk, Long userPk);
+
+    // 속한 그룹 전부 찾기
+    List<GroupMember> findByUser_UserPkAndIsAcceptedTrueAndIsOutFalse(Long userPk);
 }

--- a/src/main/java/org/solcation/solcation_be/repository/TravelRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/TravelRepository.java
@@ -6,6 +6,7 @@ import org.solcation.solcation_be.entity.TravelCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,5 +17,8 @@ public interface TravelRepository extends JpaRepository<Travel, Long> {
 
     // 그룹 + 상태별 여행 (정렬)
     List<Travel> findAllByGroup_GroupPkAndTpStateOrderByTpStartDesc(Long groupPk, TRAVELSTATE state);
+
+    // 메인페이지 현재 월별 일정 조회
+    List<Travel> findAllByGroup_GroupPkInAndTpStartLessThanEqualAndTpEndGreaterThanEqualOrderByTpStartAsc(List<Long> groupPks, LocalDate monthEnd, LocalDate monthStart);
 
 }


### PR DESCRIPTION
메인페이지 월간 여행일정 확인 가능하게 했습니다
하루라도 해당 월에 여행일정이 있으면 뜨게 했습니다
여행 시작일, 완료일, 그룹 아이콘, 그룹 명, 여행 제목 받습니다

<img width="450" height="429" alt="monthlyPlan" src="https://github.com/user-attachments/assets/9ecf227a-e113-4afc-8e73-7e688152e90f" />
