### PR TITLE
Feat: 여행 세부계획 crdt 구현

### DIFF
--- a/src/main/java/org/solcation/solcation_be/domain/travel/PlanDetailService.java
+++ b/src/main/java/org/solcation/solcation_be/domain/travel/PlanDetailService.java
@@ -1,15 +1,14 @@
 package org.solcation.solcation_be.domain.travel;
 
-import io.micrometer.common.lang.Nullable;
 import lombok.RequiredArgsConstructor;
-
 import org.solcation.solcation_be.domain.travel.dto.PlanDetailDTO;
 import org.solcation.solcation_be.domain.travel.util.Positioning;
 import org.solcation.solcation_be.entity.PlanDetail;
+import org.solcation.solcation_be.entity.TransactionCategory;
 import org.solcation.solcation_be.entity.Travel;
 import org.solcation.solcation_be.repository.PlanDetailRepository;
+import org.solcation.solcation_be.repository.TransactionCategoryRepository;
 import org.solcation.solcation_be.repository.TravelRepository;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,53 +20,71 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional
 public class PlanDetailService {
+
     private final TravelRepository travelRepository;
     private final PlanDetailRepository planDetailRepository;
+    private final TransactionCategoryRepository transactionCategoryRepository;
 
-    // 여행 세부계획 조회
+    /* 조회 */
     @Transactional(readOnly = true)
     public List<PlanDetailDTO> getTravelPlans(Long travelPk) {
-        List<PlanDetail> list = planDetailRepository.findAliveByTravelOrderByPosition(travelPk);
-        return list.stream()
-                .map(PlanDetailDTO::entityToDTO)
-                .toList();
+        return planDetailRepository.findAliveByTravelOrderByPosition(travelPk)
+                .stream().map(PlanDetailDTO::entityToDTO).toList();
     }
 
-    // 여행 세부계획 삽입
+    /* 삽입 */
     public PlanDetailDTO insertBetween(Long travelPk, int day,
-                                    String prevCrdtId, String nextCrdtId,
-                                    String pdPlace, String pdAddress, int pdCost,
-                                    String clientId, long opTs) {
+                                       String prevCrdtId, String nextCrdtId,
+                                       String pdPlace, String pdAddress, int pdCost, Long tcPk,
+                                       String clientId, Long opTs) {
+        // prev/next 보정: "0", "", "null" → null
+        prevCrdtId = normalize(prevCrdtId);
+        nextCrdtId = normalize(nextCrdtId);
+
         Travel travel = travelRepository.getReferenceById(travelPk);
+        TransactionCategory category = transactionCategoryRepository.getReferenceById(tcPk);
 
         BigDecimal newPos;
-        if(prevCrdtId == null && nextCrdtId == null) {
-            newPos = new BigDecimal("1");
+        if (prevCrdtId == null && nextCrdtId == null) {
+            // 리스트 비었으면 1, 아니면 맨 뒤
+            var tail = planDetailRepository
+                    .findTopByTravel_TpPkAndPdDayAndTombstoneFalseOrderByPositionDesc(travelPk, day);
+            newPos = tail.map(t -> Positioning.after(t.getPosition()))
+                    .orElseGet(() -> new BigDecimal("1"));
         } else if (prevCrdtId == null) {
-            PlanDetail next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+            PlanDetail next = planDetailRepository
+                    .findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(nextCrdtId, travelPk, day)
+                    .orElseThrow(() -> new IllegalArgumentException("nextCrdtId not found in travel/day"));
             newPos = Positioning.before(next.getPosition());
-
         } else if (nextCrdtId == null) {
-            PlanDetail prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
+            PlanDetail prev = planDetailRepository
+                    .findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(prevCrdtId, travelPk, day)
+                    .orElseThrow(() -> new IllegalArgumentException("prevCrdtId not found in travel/day"));
             newPos = Positioning.after(prev.getPosition());
         } else {
-            PlanDetail prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
-            PlanDetail next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+            PlanDetail prev = planDetailRepository
+                    .findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(prevCrdtId, travelPk, day)
+                    .orElseThrow(() -> new IllegalArgumentException("prevCrdtId not found in travel/day"));
+            PlanDetail next = planDetailRepository
+                    .findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(nextCrdtId, travelPk, day)
+                    .orElseThrow(() -> new IllegalArgumentException("nextCrdtId not found in travel/day"));
             newPos = Positioning.mid(prev.getPosition(), next.getPosition());
 
-            // id rebalance
-            if(newPos.compareTo(prev.getPosition()) == 0 ||
-                    newPos.compareTo(next.getPosition()) == 0) {
+            // 밀집 방어
+            if (newPos.compareTo(prev.getPosition()) <= 0 || newPos.compareTo(next.getPosition()) >= 0) {
                 rebalanceRange(travelPk, day);
-                prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
-                next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+                prev = planDetailRepository.findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(prevCrdtId, travelPk, day).orElseThrow();
+                next = planDetailRepository.findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(nextCrdtId, travelPk, day).orElseThrow();
                 newPos = Positioning.mid(prev.getPosition(), next.getPosition());
             }
         }
+
         PlanDetail created = PlanDetail.builder()
-                .crdtId(UUID.randomUUID()+":"+clientId)
+                .crdtId(UUID.randomUUID() + ":" + clientId)
+                .clientId(clientId)
                 .opTs(opTs)
                 .travel(travel)
+                .transactionCategory(category)
                 .pdDay(day)
                 .position(newPos)
                 .pdPlace(pdPlace)
@@ -79,16 +96,17 @@ public class PlanDetailService {
         return PlanDetailDTO.entityToDTO(planDetailRepository.save(created));
     }
 
-    //당일 내 이동
-    public PlanDetailDTO moveWithinDay(
-            String crdtId, String prevCrdtId, String nextCrdtId,
-            String clientId, long opTs) {
+    /* 같은 날 내 이동 */
+    public PlanDetailDTO moveWithinDay(String crdtId, String prevCrdtId, String nextCrdtId,
+                                       String clientId, Long opTs) {
 
-        PlanDetail target = planDetailRepository.findByCrdtId(crdtId).orElseThrow();
+        PlanDetail target = planDetailRepository.findByCrdtId(crdtId)
+                .orElseThrow(() -> new IllegalArgumentException("crdtId not found: " + crdtId));
+
         Long travelId = target.getTravel().getTpPk();
         int day = target.getPdDay();
 
-        BigDecimal newPos = computeNewPosition(travelId, day, prevCrdtId, nextCrdtId);
+        BigDecimal newPos = computeNewPosition(travelId, day, normalize(prevCrdtId), normalize(nextCrdtId));
 
         target.setPosition(newPos);
         target.setClientId(clientId);
@@ -96,42 +114,45 @@ public class PlanDetailService {
         return PlanDetailDTO.entityToDTO(target);
     }
 
-    //다른 날짜로 이동
-    public PlanDetailDTO moveToAnotherDay(
-            String crdtId, int newDay, String prevCrdtId, String nextCrdtId,
-            String clientId, long opTs) {
+    /* 다른 날짜로 이동 */
+    public PlanDetailDTO moveToAnotherDay(String crdtId, int newDay,
+                                          String prevCrdtId, String nextCrdtId,
+                                          String clientId, Long opTs) {
 
-        PlanDetail target = planDetailRepository.findByCrdtId(crdtId).orElseThrow();
+        PlanDetail target = planDetailRepository.findByCrdtId(crdtId)
+                .orElseThrow(() -> new IllegalArgumentException("crdtId not found: " + crdtId));
         Long travelId = target.getTravel().getTpPk();
 
-        BigDecimal newPos = computeNewPosition(travelId, newDay, prevCrdtId, nextCrdtId);
+        BigDecimal newPos = computeNewPosition(travelId, newDay, normalize(prevCrdtId), normalize(nextCrdtId));
 
         target.setPosition(newPos);
-        target.setClientId(clientId);
-        target.setOpTs(opTs);
         target.setPdDay(newDay);
-
-        return PlanDetailDTO.entityToDTO(target);
-    }
-
-    //세부계획 카드 수정
-    public PlanDetailDTO updateFields( String crdtId, String pdPlace, String pdAddress,
-                                    Integer pdCost, String clientId, long opTs) {
-
-        PlanDetail target = planDetailRepository.findByCrdtId(crdtId).orElseThrow();
-
-        target.setPdPlace(pdPlace);
-        target.setPdAddress(pdAddress);
-        target.setPdCost(pdCost);
         target.setClientId(clientId);
         target.setOpTs(opTs);
-
         return PlanDetailDTO.entityToDTO(target);
     }
 
-    //삭제
-    public void softDelete(String crdtId, String clientId, long opTs) {
-        PlanDetail target = planDetailRepository.findByCrdtId(crdtId).orElseThrow();
+    /* 내용 수정 (선택적 업데이트) */
+    public PlanDetailDTO updateFields(String crdtId, String pdPlace, String pdAddress,
+                                      Integer pdCost, Long tcPk, String clientId, Long opTs) {
+
+        PlanDetail target = planDetailRepository.findByCrdtId(crdtId)
+                .orElseThrow(() -> new IllegalArgumentException("crdtId not found: " + crdtId));
+
+        if (pdPlace != null)   target.setPdPlace(pdPlace);
+        if (pdAddress != null) target.setPdAddress(pdAddress);
+        if (pdCost != null)    target.setPdCost(pdCost);
+        if (tcPk != null)      target.setTransactionCategory(transactionCategoryRepository.getReferenceById(tcPk));
+
+        target.setClientId(clientId);
+        target.setOpTs(opTs);
+        return PlanDetailDTO.entityToDTO(target);
+    }
+
+    /* 소프트 삭제 */
+    public void softDelete(String crdtId, String clientId, Long opTs) {
+        PlanDetail target = planDetailRepository.findByCrdtId(crdtId)
+                .orElseThrow(() -> new IllegalArgumentException("crdtId not found: " + crdtId));
         if (!target.isTombstone()) {
             target.setTombstone(true);
             target.setOpTs(opTs);
@@ -139,41 +160,61 @@ public class PlanDetailService {
         }
     }
 
-    //이동 위치 계산
+    /* 위치 계산 (여행/날짜 스코프로 prev/next 검색) */
     private BigDecimal computeNewPosition(Long travelId, int day, String prevCrdtId, String nextCrdtId) {
-        if (prevCrdtId == null && nextCrdtId == null) return new BigDecimal("1");
+        if (prevCrdtId == null && nextCrdtId == null) {
+            var tail = planDetailRepository
+                    .findTopByTravel_TpPkAndPdDayAndTombstoneFalseOrderByPositionDesc(travelId, day);
+            return tail.map(t -> Positioning.after(t.getPosition()))
+                    .orElseGet(() -> new BigDecimal("1"));
+        }
         if (prevCrdtId == null) {
-            PlanDetail next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+            PlanDetail next = planDetailRepository
+                    .findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(nextCrdtId, travelId, day)
+                    .orElseThrow(() -> new IllegalArgumentException("nextCrdtId not found in travel/day"));
             return Positioning.before(next.getPosition());
         }
         if (nextCrdtId == null) {
-            PlanDetail prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
+            PlanDetail prev = planDetailRepository
+                    .findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(prevCrdtId, travelId, day)
+                    .orElseThrow(() -> new IllegalArgumentException("prevCrdtId not found in travel/day"));
             return Positioning.after(prev.getPosition());
         }
-        PlanDetail prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
-        PlanDetail next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+        PlanDetail prev = planDetailRepository
+                .findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(prevCrdtId, travelId, day)
+                .orElseThrow(() -> new IllegalArgumentException("prevCrdtId not found in travel/day"));
+        PlanDetail next = planDetailRepository
+                .findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(nextCrdtId, travelId, day)
+                .orElseThrow(() -> new IllegalArgumentException("nextCrdtId not found in travel/day"));
+
         BigDecimal mid = Positioning.mid(prev.getPosition(), next.getPosition());
-        if (mid.compareTo(prev.getPosition()) == 0 || mid.compareTo(next.getPosition()) == 0) {
+        if (mid.compareTo(prev.getPosition()) <= 0 || mid.compareTo(next.getPosition()) >= 0) {
             rebalanceRange(travelId, day);
-            prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
-            next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+            prev = planDetailRepository.findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(prevCrdtId, travelId, day).orElseThrow();
+            next = planDetailRepository.findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(nextCrdtId, travelId, day).orElseThrow();
             mid = Positioning.mid(prev.getPosition(), next.getPosition());
         }
         return mid;
     }
 
-    //id가 촘촘할때 재배치
+    /* 리밸런스: 해당 day만 등차수열로 재부여 */
     public void rebalanceRange(Long travelId, int day) {
         List<PlanDetail> list = planDetailRepository.findAliveByTravelAndDayOrderByPosition(travelId, day);
         BigDecimal step = new BigDecimal("10");
         BigDecimal cur = step;
 
         for (PlanDetail p : list) {
-            p.setPosition(step.add(p.getPosition()));
+            p.setPosition(cur);
             cur = cur.add(step);
         }
     }
 
-
-
+    private static String normalize(String raw) {
+        if (raw == null) return null;
+        String t = raw.trim();
+        if (t.isEmpty()) return null;
+        if ("0".equals(t)) return null;
+        if ("null".equalsIgnoreCase(t)) return null;
+        return t;
+    }
 }

--- a/src/main/java/org/solcation/solcation_be/domain/travel/PlanDetailService.java
+++ b/src/main/java/org/solcation/solcation_be/domain/travel/PlanDetailService.java
@@ -1,0 +1,179 @@
+package org.solcation.solcation_be.domain.travel;
+
+import io.micrometer.common.lang.Nullable;
+import lombok.RequiredArgsConstructor;
+
+import org.solcation.solcation_be.domain.travel.dto.PlanDetailDTO;
+import org.solcation.solcation_be.domain.travel.util.Positioning;
+import org.solcation.solcation_be.entity.PlanDetail;
+import org.solcation.solcation_be.entity.Travel;
+import org.solcation.solcation_be.repository.PlanDetailRepository;
+import org.solcation.solcation_be.repository.TravelRepository;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlanDetailService {
+    private final TravelRepository travelRepository;
+    private final PlanDetailRepository planDetailRepository;
+
+    // 여행 세부계획 조회
+    @Transactional(readOnly = true)
+    public List<PlanDetailDTO> getTravelPlans(Long travelPk) {
+        List<PlanDetail> list = planDetailRepository.findAliveByTravelOrderByPosition(travelPk);
+        return list.stream()
+                .map(PlanDetailDTO::entityToDTO)
+                .toList();
+    }
+
+    // 여행 세부계획 삽입
+    public PlanDetailDTO insertBetween(Long travelPk, int day,
+                                    String prevCrdtId, String nextCrdtId,
+                                    String pdPlace, String pdAddress, int pdCost,
+                                    String clientId, long opTs) {
+        Travel travel = travelRepository.getReferenceById(travelPk);
+
+        BigDecimal newPos;
+        if(prevCrdtId == null && nextCrdtId == null) {
+            newPos = new BigDecimal("1");
+        } else if (prevCrdtId == null) {
+            PlanDetail next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+            newPos = Positioning.before(next.getPosition());
+
+        } else if (nextCrdtId == null) {
+            PlanDetail prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
+            newPos = Positioning.after(prev.getPosition());
+        } else {
+            PlanDetail prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
+            PlanDetail next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+            newPos = Positioning.mid(prev.getPosition(), next.getPosition());
+
+            // id rebalance
+            if(newPos.compareTo(prev.getPosition()) == 0 ||
+                    newPos.compareTo(next.getPosition()) == 0) {
+                rebalanceRange(travelPk, day);
+                prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
+                next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+                newPos = Positioning.mid(prev.getPosition(), next.getPosition());
+            }
+        }
+        PlanDetail created = PlanDetail.builder()
+                .crdtId(UUID.randomUUID()+":"+clientId)
+                .opTs(opTs)
+                .travel(travel)
+                .pdDay(day)
+                .position(newPos)
+                .pdPlace(pdPlace)
+                .pdAddress(pdAddress)
+                .pdCost(pdCost)
+                .tombstone(false)
+                .build();
+
+        return PlanDetailDTO.entityToDTO(planDetailRepository.save(created));
+    }
+
+    //당일 내 이동
+    public PlanDetailDTO moveWithinDay(
+            String crdtId, String prevCrdtId, String nextCrdtId,
+            String clientId, long opTs) {
+
+        PlanDetail target = planDetailRepository.findByCrdtId(crdtId).orElseThrow();
+        Long travelId = target.getTravel().getTpPk();
+        int day = target.getPdDay();
+
+        BigDecimal newPos = computeNewPosition(travelId, day, prevCrdtId, nextCrdtId);
+
+        target.setPosition(newPos);
+        target.setClientId(clientId);
+        target.setOpTs(opTs);
+        return PlanDetailDTO.entityToDTO(target);
+    }
+
+    //다른 날짜로 이동
+    public PlanDetailDTO moveToAnotherDay(
+            String crdtId, int newDay, String prevCrdtId, String nextCrdtId,
+            String clientId, long opTs) {
+
+        PlanDetail target = planDetailRepository.findByCrdtId(crdtId).orElseThrow();
+        Long travelId = target.getTravel().getTpPk();
+
+        BigDecimal newPos = computeNewPosition(travelId, newDay, prevCrdtId, nextCrdtId);
+
+        target.setPosition(newPos);
+        target.setClientId(clientId);
+        target.setOpTs(opTs);
+        target.setPdDay(newDay);
+
+        return PlanDetailDTO.entityToDTO(target);
+    }
+
+    //세부계획 카드 수정
+    public PlanDetailDTO updateFields( String crdtId, String pdPlace, String pdAddress,
+                                    Integer pdCost, String clientId, long opTs) {
+
+        PlanDetail target = planDetailRepository.findByCrdtId(crdtId).orElseThrow();
+
+        target.setPdPlace(pdPlace);
+        target.setPdAddress(pdAddress);
+        target.setPdCost(pdCost);
+        target.setClientId(clientId);
+        target.setOpTs(opTs);
+
+        return PlanDetailDTO.entityToDTO(target);
+    }
+
+    //삭제
+    public void softDelete(String crdtId, String clientId, long opTs) {
+        PlanDetail target = planDetailRepository.findByCrdtId(crdtId).orElseThrow();
+        if (!target.isTombstone()) {
+            target.setTombstone(true);
+            target.setOpTs(opTs);
+            target.setClientId(clientId);
+        }
+    }
+
+    //이동 위치 계산
+    private BigDecimal computeNewPosition(Long travelId, int day, String prevCrdtId, String nextCrdtId) {
+        if (prevCrdtId == null && nextCrdtId == null) return new BigDecimal("1");
+        if (prevCrdtId == null) {
+            PlanDetail next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+            return Positioning.before(next.getPosition());
+        }
+        if (nextCrdtId == null) {
+            PlanDetail prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
+            return Positioning.after(prev.getPosition());
+        }
+        PlanDetail prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
+        PlanDetail next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+        BigDecimal mid = Positioning.mid(prev.getPosition(), next.getPosition());
+        if (mid.compareTo(prev.getPosition()) == 0 || mid.compareTo(next.getPosition()) == 0) {
+            rebalanceRange(travelId, day);
+            prev = planDetailRepository.findByCrdtId(prevCrdtId).orElseThrow();
+            next = planDetailRepository.findByCrdtId(nextCrdtId).orElseThrow();
+            mid = Positioning.mid(prev.getPosition(), next.getPosition());
+        }
+        return mid;
+    }
+
+    //id가 촘촘할때 재배치
+    public void rebalanceRange(Long travelId, int day) {
+        List<PlanDetail> list = planDetailRepository.findAliveByTravelAndDayOrderByPosition(travelId, day);
+        BigDecimal step = new BigDecimal("10");
+        BigDecimal cur = step;
+
+        for (PlanDetail p : list) {
+            p.setPosition(step.add(p.getPosition()));
+            cur = cur.add(step);
+        }
+    }
+
+
+
+}

--- a/src/main/java/org/solcation/solcation_be/domain/travel/TravelController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/travel/TravelController.java
@@ -4,50 +4,167 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.solcation.solcation_be.domain.travel.dto.PlanDetailDTO;
 import org.solcation.solcation_be.domain.travel.dto.TravelReqDTO;
 import org.solcation.solcation_be.domain.travel.dto.TravelResDTO;
 import org.solcation.solcation_be.entity.TRAVELSTATE;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
 
 @Tag(name = "여행 계획 컨트롤러")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/group/{groupId:\\d+}/travel")
 public class TravelController {
+
     private final TravelService travelService;
+    private final PlanDetailService planDetailService;
 
     @Operation(summary = "그룹 여행 조회", description = "status가 없으면 전체, 있으면 상태별 필터")
     @GetMapping("/list")
-    public List<TravelResDTO> getTravels( @PathVariable Long groupId,
+    public List<TravelResDTO> getTravels(
+            @PathVariable Long groupId,
             @RequestParam(name = "status", required = false) TRAVELSTATE status
     ) {
-        List<TravelResDTO> result;
         if (status == null) {
-            result = travelService.getTravelsByGroup(groupId);
-        } else {
-            result = travelService.getTravelsByGroupAndStatus(groupId, status);
+            return travelService.getTravelsByGroup(groupId);
         }
-        return result;
+        return travelService.getTravelsByGroupAndStatus(groupId, status);
     }
 
     @Operation(summary = "그룹 여행 생성")
-    @PostMapping(value="/new", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/new", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public Long createTravel(@PathVariable Long groupId, @Valid @ModelAttribute TravelReqDTO dto) {
         dto.setGroupPk(groupId);
         return travelService.create(dto);
     }
 
     @Operation(summary = "단일 여행 조회")
-    @GetMapping(value="/{travelId}")
+    @GetMapping("/{travelId}")
     public TravelResDTO getTravel(@PathVariable Long groupId, @PathVariable Long travelId) {
         return travelService.getTravelById(travelId);
     }
 
+    //세부계획
+    @Operation(summary = "여행 세부계획 조회")
+    @GetMapping("/{travelId}/plans")
+    public List<PlanDetailDTO> getTravelPlans(
+            @PathVariable Long groupId,
+            @PathVariable Long travelId
+    ) {
+        return planDetailService.getTravelPlans(travelId);
+    }
+
+    @Operation(summary = "여행 세부계획 삽입")
+    @PostMapping("/{travelId}/insert")
+    public PlanDetailDTO insertPlanDetail(
+            @PathVariable Long groupId,
+            @PathVariable Long travelId,
+            @Valid @RequestBody InsertReq req
+    ) {
+        return planDetailService.insertBetween(
+                travelId, req.pdDay(),
+                req.prevCrdtId(), req.nextCrdtId(),
+                req.pdPlace(), req.pdAddress(), req.pdCost(),
+                req.clientId(), req.opTs()
+        );
+    }
+
+    @Operation(summary = "같은 날 내 순서 이동")
+    @PostMapping("/{travelId}/move/within")
+    public PlanDetailDTO moveWithinDay(
+            @PathVariable Long groupId,
+            @PathVariable Long travelId,
+            @Valid @RequestBody MoveWithinReq req
+    ) {
+        return planDetailService.moveWithinDay(
+                req.crdtId(), req.prevCrdtId(), req.nextCrdtId(),
+                req.clientId(), req.opTs()
+        );
+    }
+
+    @Operation(summary = "다른 날로 이동")
+    @PostMapping("/{travelId}/move/day")
+    public PlanDetailDTO moveToAnotherDay(
+            @PathVariable Long groupId,
+            @PathVariable Long travelId,
+            @Valid @RequestBody MoveDayReq req
+    ) {
+        return planDetailService.moveToAnotherDay(
+                req.crdtId(), req.newDay(),
+                req.prevCrdtId(), req.nextCrdtId(),
+                req.clientId(), req.opTs()
+        );
+    }
+
+    @Operation(summary = "세부계획 내용 수정")
+    @PatchMapping("/{travelId}/update")
+    public PlanDetailDTO updatePlanDetail(
+            @PathVariable Long groupId,
+            @PathVariable Long travelId,
+            @Valid @RequestBody UpdateReq req
+    ) {
+        return planDetailService.updateFields(
+                req.crdtId(), req.pdPlace(), req.pdAddress(), req.pdCost(),
+                req.clientId(), req.opTs()
+        );
+    }
+
+    @Operation(summary = "세부계획 삭제(소프트)")
+    @DeleteMapping("/{travelId}/{crdtId}")
+    public ResponseEntity<Void> deletePlanDetail(
+            @PathVariable Long groupId,
+            @PathVariable Long travelId,
+            @PathVariable String crdtId,
+            @RequestParam String clientId,
+            @RequestParam long opTs
+    ) {
+        planDetailService.softDelete(crdtId, clientId, opTs);
+        return ResponseEntity.noContent().build();
+    }
 
 
+    /** 삽입 요청 */
+    public record InsertReq(
+            int pdDay,
+            String prevCrdtId,
+            String nextCrdtId,
+            String pdPlace,
+            String pdAddress,
+            Integer pdCost,
+            String clientId,
+            long opTs
+    ) {}
 
+    /** 같은 날 내 이동 */
+    public record MoveWithinReq(
+            String crdtId,
+            String prevCrdtId,
+            String nextCrdtId,
+            String clientId,
+            long opTs
+    ) {}
+
+    /** 다른 날로 이동 */
+    public record MoveDayReq(
+            String crdtId,
+            int newDay,
+            String prevCrdtId,
+            String nextCrdtId,
+            String clientId,
+            long opTs
+    ) {}
+
+    /** 내용 수정 */
+    public record UpdateReq(
+            String crdtId,
+            String pdPlace,
+            String pdAddress,
+            Integer pdCost,
+            String clientId,
+            long opTs
+    ) {}
 }

--- a/src/main/java/org/solcation/solcation_be/domain/travel/TravelController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/travel/TravelController.java
@@ -68,7 +68,7 @@ public class TravelController {
         return planDetailService.insertBetween(
                 travelId, req.pdDay(),
                 req.prevCrdtId(), req.nextCrdtId(),
-                req.pdPlace(), req.pdAddress(), req.pdCost(),
+                req.pdPlace(), req.pdAddress(), req.pdCost(), req.tcPk(),
                 req.clientId(), req.opTs()
         );
     }
@@ -108,7 +108,7 @@ public class TravelController {
             @Valid @RequestBody UpdateReq req
     ) {
         return planDetailService.updateFields(
-                req.crdtId(), req.pdPlace(), req.pdAddress(), req.pdCost(),
+                req.crdtId(), req.pdPlace(), req.pdAddress(), req.pdCost(), req.tcPk(),
                 req.clientId(), req.opTs()
         );
     }
@@ -120,7 +120,7 @@ public class TravelController {
             @PathVariable Long travelId,
             @PathVariable String crdtId,
             @RequestParam String clientId,
-            @RequestParam long opTs
+            @RequestParam Long opTs
     ) {
         planDetailService.softDelete(crdtId, clientId, opTs);
         return ResponseEntity.noContent().build();
@@ -134,9 +134,10 @@ public class TravelController {
             String nextCrdtId,
             String pdPlace,
             String pdAddress,
-            Integer pdCost,
+            int pdCost,
+            Long tcPk,
             String clientId,
-            long opTs
+            Long opTs
     ) {}
 
     /** 같은 날 내 이동 */
@@ -145,7 +146,7 @@ public class TravelController {
             String prevCrdtId,
             String nextCrdtId,
             String clientId,
-            long opTs
+            Long opTs
     ) {}
 
     /** 다른 날로 이동 */
@@ -155,7 +156,7 @@ public class TravelController {
             String prevCrdtId,
             String nextCrdtId,
             String clientId,
-            long opTs
+            Long opTs
     ) {}
 
     /** 내용 수정 */
@@ -163,8 +164,9 @@ public class TravelController {
             String crdtId,
             String pdPlace,
             String pdAddress,
-            Integer pdCost,
+            int pdCost,
+            Long tcPk,
             String clientId,
-            long opTs
+            Long opTs
     ) {}
 }

--- a/src/main/java/org/solcation/solcation_be/domain/travel/TravelController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/travel/TravelController.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Tag(name = "여행 계획 컨트롤러")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/group/{groupId}/travel")
+@RequestMapping("/group/{groupId:\\d+}/travel")
 public class TravelController {
     private final TravelService travelService;
 

--- a/src/main/java/org/solcation/solcation_be/domain/travel/TravelService.java
+++ b/src/main/java/org/solcation/solcation_be/domain/travel/TravelService.java
@@ -7,10 +7,7 @@ import org.solcation.solcation_be.common.CustomException;
 import org.solcation.solcation_be.common.ErrorCode;
 import org.solcation.solcation_be.domain.travel.dto.TravelReqDTO;
 import org.solcation.solcation_be.domain.travel.dto.TravelResDTO;
-import org.solcation.solcation_be.entity.Group;
-import org.solcation.solcation_be.entity.TRAVELSTATE;
-import org.solcation.solcation_be.entity.Travel;
-import org.solcation.solcation_be.entity.TravelCategory;
+import org.solcation.solcation_be.entity.*;
 import org.solcation.solcation_be.repository.GroupRepository;
 import org.solcation.solcation_be.repository.TravelCategoryRepository;
 import org.solcation.solcation_be.repository.TravelRepository;
@@ -77,6 +74,7 @@ public class TravelService {
         return group.getGroupPk();
     }
 
+    // 단일 여행 조회
     public TravelResDTO getTravelById(Long travelPk) {
         return travelRepository.findById(travelPk)
                 .map(this::toDto)

--- a/src/main/java/org/solcation/solcation_be/domain/travel/dto/PlanDetailDTO.java
+++ b/src/main/java/org/solcation/solcation_be/domain/travel/dto/PlanDetailDTO.java
@@ -1,15 +1,8 @@
 package org.solcation.solcation_be.domain.travel.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
 import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.time.LocalDate;
+import org.solcation.solcation_be.entity.PlanDetail;
+import org.solcation.solcation_be.entity.Travel;
 
 @Getter
 @Setter
@@ -18,41 +11,60 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class PlanDetailDTO {
 
-    @Schema(description = "그룹 pk", example = "1")
-    @NotNull(message = "그룹을 선택해주세요") @Positive
-    private Long groupPk;
+    // PK
+    private Long pdPk;
 
-    @Schema(description = "국가", example = "대한민국")
-    @NotBlank(message = "국가를 선택해주세요")
-    @Size(max = 60)
-    private String country;
+    // 소속 Travel (엔티티 대신 id만)
+    private Long travelId;
 
-    @Schema(description = "도시", example = "제주")
-    @NotBlank(message = "도시를 선택해주세요")
-    @Size(max = 60)
-    private String city;
+    // 일정 기본 정보
+    private int pdDay;
+    private String pdPlace;
+    private String pdAddress;
+    private int pdCost;
 
-    @Schema(description = "여행 제목", example = "제주도 2박3일")
-    @NotBlank(message = "여행 제목을 입력해주세요")
-    @Size(max = 100)
-    private String title;
+    // 정렬/CRDT 메타
+    // BigDecimal → 문자열로 노출(직렬화/정밀도 안전)
+    private String position;
+    private String crdtId;
+    private String clientId;
+    private Long opTs;
+    private boolean tombstone;
 
-    @Schema(description = "시작일", type = "string", example = "2025-09-20", format = "date")
-    @NotNull(message = "시작일을 선택해주세요")
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) // @ModelAttribute(multipart)용
-    private LocalDate startDate;
+    private String prevCrdtId;
+    private String nextCrdtId;
+    private int newDay;
 
-    @Schema(description = "종료일", type = "string", example = "2025-09-22", format = "date")
-    @NotNull(message = "종료일을 선택해주세요")
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-    private LocalDate endDate;
+    /** 엔티티 → DTO */
+    public static PlanDetailDTO entityToDTO(PlanDetail e) {
+        return PlanDetailDTO.builder()
+                .pdPk(e.getPdPk())
+                .travelId(e.getTravel() != null ? e.getTravel().getTpPk() : null)
+                .pdDay(e.getPdDay())
+                .pdPlace(e.getPdPlace())
+                .pdAddress(e.getPdAddress())
+                .pdCost(e.getPdCost())
+                .position(e.getPosition() != null ? e.getPosition().toPlainString() : null)
+                .crdtId(e.getCrdtId())
+                .clientId(e.getClientId())
+                .opTs(e.getOpTs())
+                .tombstone(e.isTombstone())
+                .build();
+    }
 
-    @Schema(description = "카테고리 PK", example = "3")
-    @NotNull(message = "테마를 선택해주세요")
-    @Positive(message = "유효한 카테고리를 선택해주세요")
-    private Long categoryPk;
-
-    @Schema(description = "대표 사진 파일", type = "string", format = "binary")
-    @NotNull(message = "이미지를 선택해주세요")
-    private MultipartFile photo;
+    public PlanDetail dtoToEntity(Travel travel) {
+        return PlanDetail.builder()
+                .pdPk(pdPk)
+                .travel(travel)
+                .pdDay(pdDay)
+                .pdPlace(pdPlace)
+                .pdAddress(pdAddress)
+                .pdCost(pdCost)
+                .position(position != null ? new java.math.BigDecimal(position) : null)
+                .crdtId(crdtId)
+                .clientId(clientId)
+                .opTs(opTs)
+                .tombstone(tombstone)
+                .build();
+    }
 }

--- a/src/main/java/org/solcation/solcation_be/domain/travel/util/Positioning.java
+++ b/src/main/java/org/solcation/solcation_be/domain/travel/util/Positioning.java
@@ -1,0 +1,24 @@
+package org.solcation.solcation_be.domain.travel.util;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+
+public final class Positioning {
+    private static final MathContext MC = new MathContext(38, RoundingMode.HALF_UP);
+
+    //중간에 삽입될때
+    public static BigDecimal mid(BigDecimal a, BigDecimal b) {
+        return a.add(b).divide(new BigDecimal("2"), MC);
+    }
+
+    //맨 앞 삽입
+    public static BigDecimal before(BigDecimal next) {
+        return next.divide(new BigDecimal("2"), MC);
+    }
+
+    //맨 뒤 삽입
+    public static BigDecimal after(BigDecimal prev) {
+        return prev.add(BigDecimal.ONE, MC);
+    }
+}

--- a/src/main/java/org/solcation/solcation_be/entity/PlanDetail.java
+++ b/src/main/java/org/solcation/solcation_be/entity/PlanDetail.java
@@ -50,4 +50,8 @@ public class PlanDetail {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "tp_pk", nullable = false)
     private Travel travel;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "tc_pk", nullable = false)
+    private TransactionCategory transactionCategory;
 }

--- a/src/main/java/org/solcation/solcation_be/entity/PlanDetail.java
+++ b/src/main/java/org/solcation/solcation_be/entity/PlanDetail.java
@@ -3,11 +3,14 @@ package org.solcation.solcation_be.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Entity
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 @Table(name = "plan_detail_tb")
 public class PlanDetail {
     @Id
@@ -27,8 +30,21 @@ public class PlanDetail {
     @Column(name = "pd_day", nullable = false)
     private int pdDay;
 
-    @Column(name = "pd_order", nullable = false)
-    private int pdOrder;
+    @Column(name = "pd_order", precision = 38, scale = 18, nullable = false)
+    private BigDecimal position;
+
+    // CRDT 메타
+    @Column(name = "crdt_id", nullable = false, unique = true, length = 64)
+    private String crdtId;              // UUID + clientId 조합 (멱등키)
+
+    @Column(name = "client_id", nullable = false, length = 64)
+    private String clientId;            // 생성/변경 주체
+
+    @Column(name = "op_ts", nullable = false)
+    private Long opTs;
+
+    @Column(name = "tombstone", nullable = false)
+    private boolean tombstone;          // 소프트 삭제
 
     @Setter
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/org/solcation/solcation_be/entity/TransactionCategory.java
+++ b/src/main/java/org/solcation/solcation_be/entity/TransactionCategory.java
@@ -1,0 +1,25 @@
+package org.solcation.solcation_be.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "transaction_category_tb")
+public class TransactionCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="tc_pk")
+    private Long tcPk;
+
+    @Column(name="tc_name")
+    private String tcName;
+
+    @Column(name="tc_icon")
+    private String tcIcon; //파일 경로
+
+}

--- a/src/main/java/org/solcation/solcation_be/entity/Travel.java
+++ b/src/main/java/org/solcation/solcation_be/entity/Travel.java
@@ -53,19 +53,4 @@ public class Travel {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_pk", nullable = false)
     private Group group;
-
-    @Builder.Default
-    @OneToMany(mappedBy = "travel", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("pdDay ASC, pdOrder ASC")
-    private List<PlanDetail> details = new ArrayList<>();
-
-    public void addDetail(PlanDetail d) {
-        details.add(d);
-        d.setTravel(this);
-    }
-
-    public void removeDetail(PlanDetail d) {
-        details.remove(d);
-        d.setTravel(null);
-    }
 }

--- a/src/main/java/org/solcation/solcation_be/repository/PlanDetailRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/PlanDetailRepository.java
@@ -16,30 +16,31 @@ import java.util.Optional;
 public interface PlanDetailRepository extends JpaRepository<PlanDetail, Long> {
 
     // 같은 여행ID, tombstone=false 정렬 조회
-    @Query("select p from PlanDetail p " +
-            "where p.travel.tpPk = :travelId and p.tombstone = false " +
-            "order by p.position asc, p.opTs asc, p.clientId asc, p.crdtId asc")
-    List<PlanDetail> findAliveByTravelOrderByPosition(
-            @Param("travelId") Long travelId);
+    @Query("""
+        select p from PlanDetail p
+        where p.travel.tpPk = :travelId and p.tombstone = false
+        order by p.pdDay asc, p.position asc, p.opTs asc, p.clientId asc, p.crdtId asc
+    """)
+    List<PlanDetail> findAliveByTravelOrderByPosition(@Param("travelId") Long travelId);
 
     // 같은 여행ID, 같은 Day, tombstone=false 만 정렬 조회
-    @Query("select p from PlanDetail p " +
-            "where p.travel.tpPk = :travelId and p.pdDay = :day and p.tombstone = false " +
-            "order by p.position asc, p.opTs asc, p.clientId asc, p.crdtId asc")
+    @Query("""
+        select p from PlanDetail p
+        where p.travel.tpPk = :travelId and p.pdDay = :day and p.tombstone = false
+        order by p.position asc, p.opTs asc, p.clientId asc, p.crdtId asc
+    """)
     List<PlanDetail> findAliveByTravelAndDayOrderByPosition(
             @Param("travelId") Long travelId, @Param("day") Integer day);
 
     Optional<PlanDetail> findByCrdtId(String crdtId);
 
-    // prev/next를 찾을 때 사용 (동일 day, 동일 travel)
-    @Query("select p from PlanDetail p " +
-            "where p.travel.tpPk = :travelId and p.pdDay = :day and p.tombstone = false " +
-            "and p.position < :pos order by p.position desc")
-    List<PlanDetail> findPrev(@Param("travelId") Long travelId, @Param("day") int day, @Param("pos") BigDecimal pos, Pageable pageable);
+    // 같은 여행/같은 day에서 tail(맨 뒤) 하나만
+    Optional<PlanDetail> findTopByTravel_TpPkAndPdDayAndTombstoneFalseOrderByPositionDesc(
+            Long travelId, int pdDay
+    );
 
-    @Query("select p from PlanDetail p " +
-            "where p.travel.tpPk = :travelId and p.pdDay = :day and p.tombstone = false " +
-            "and p.position > :pos order by p.position asc")
-    List<PlanDetail> findNext(@Param("travelId") Long travelId, @Param("day") int day, @Param("pos") BigDecimal pos, Pageable pageable);
-
+    // 같은 여행/같은 day에서 crdtId로 찾기 (prev/next 안전 조회)
+    Optional<PlanDetail> findByCrdtIdAndTravel_TpPkAndPdDayAndTombstoneFalse(
+            String crdtId, Long travelId, int pdDay
+    );
 }

--- a/src/main/java/org/solcation/solcation_be/repository/PlanDetailRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/PlanDetailRepository.java
@@ -1,0 +1,45 @@
+package org.solcation.solcation_be.repository;
+
+import org.solcation.solcation_be.entity.PlanDetail;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PlanDetailRepository extends JpaRepository<PlanDetail, Long> {
+
+    // 같은 여행ID, tombstone=false 정렬 조회
+    @Query("select p from PlanDetail p " +
+            "where p.travel.tpPk = :travelId and p.tombstone = false " +
+            "order by p.position asc, p.opTs asc, p.clientId asc, p.crdtId asc")
+    List<PlanDetail> findAliveByTravelOrderByPosition(
+            @Param("travelId") Long travelId);
+
+    // 같은 여행ID, 같은 Day, tombstone=false 만 정렬 조회
+    @Query("select p from PlanDetail p " +
+            "where p.travel.tpPk = :travelId and p.pdDay = :day and p.tombstone = false " +
+            "order by p.position asc, p.opTs asc, p.clientId asc, p.crdtId asc")
+    List<PlanDetail> findAliveByTravelAndDayOrderByPosition(
+            @Param("travelId") Long travelId, @Param("day") Integer day);
+
+    Optional<PlanDetail> findByCrdtId(String crdtId);
+
+    // prev/next를 찾을 때 사용 (동일 day, 동일 travel)
+    @Query("select p from PlanDetail p " +
+            "where p.travel.tpPk = :travelId and p.pdDay = :day and p.tombstone = false " +
+            "and p.position < :pos order by p.position desc")
+    List<PlanDetail> findPrev(@Param("travelId") Long travelId, @Param("day") int day, @Param("pos") BigDecimal pos, Pageable pageable);
+
+    @Query("select p from PlanDetail p " +
+            "where p.travel.tpPk = :travelId and p.pdDay = :day and p.tombstone = false " +
+            "and p.position > :pos order by p.position asc")
+    List<PlanDetail> findNext(@Param("travelId") Long travelId, @Param("day") int day, @Param("pos") BigDecimal pos, Pageable pageable);
+
+}

--- a/src/main/java/org/solcation/solcation_be/repository/TransactionCategoryRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/TransactionCategoryRepository.java
@@ -1,0 +1,10 @@
+package org.solcation.solcation_be.repository;
+
+import org.solcation.solcation_be.entity.GroupCategory;
+import org.solcation.solcation_be.entity.TransactionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TransactionCategoryRepository extends JpaRepository<TransactionCategory, Long> {
+}

--- a/src/main/java/org/solcation/solcation_be/repository/TravelCategoryRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/TravelCategoryRepository.java
@@ -1,7 +1,5 @@
 package org.solcation.solcation_be.repository;
 
-import org.solcation.solcation_be.entity.TRAVELSTATE;
-import org.solcation.solcation_be.entity.Travel;
 import org.solcation.solcation_be.entity.TravelCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;


### PR DESCRIPTION
DB 수정 사항:
소비카테고리 칼럼 추가
CRDT 구현 관련 칼럼 추가
- crdtId : UUID + clientId (카드용 멱등키)
- clidentId : 수정한 유저
- opTs : 타임스탬프 (연산 순서 정렬용)
- tombstone : 삭제 여부
=> 지라 sql문에 반영되어있습니다

구현 기능:
- 계획 삽입
- 계획 수정
- 당일 내 순서 이동
- 일자 간 순서 이동
- 삭제 -> db에는 남겨두고 삭제 처리

/travel/util/Positioning : crdt 관련 id로 순서를 조정 및 재배치하는 함수들
