### PR TITLE
Feat: 완료한 여행 총계, 카테고리별 합계, 다른 그룹과 비교 구현

### DIFF
--- a/src/main/java/org/solcation/solcation_be/domain/main/MainController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/main/MainController.java
@@ -1,5 +1,7 @@
 package org.solcation.solcation_be.domain.main;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.solcation.solcation_be.common.CustomException;
 import org.solcation.solcation_be.common.ErrorCode;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "메인 컨트롤러")
 @RestController
 @RequestMapping("/main")
 @RequiredArgsConstructor
@@ -27,6 +30,7 @@ public class MainController {
     private final MainService mainService;
     private final UserRepository userRepository;
 
+    @Operation(summary = "사용자 그룹 조회")
     @GetMapping("/my-groups")
     public List<GroupShortDTO> getMyGroups(
             @AuthenticationPrincipal JwtPrincipal principal
@@ -38,6 +42,7 @@ public class MainController {
         return mainService.getUserGroups(userPk);
     }
 
+    @Operation(summary = "사용자 정보 조회")
     @GetMapping("/mypage")
     public MyPageDTO getMyPage(
             @AuthenticationPrincipal JwtPrincipal principal
@@ -49,6 +54,7 @@ public class MainController {
         return mainService.getMyPage(userPk);
     }
 
+    @Operation(summary = "최근 알림 2개 미리보기")
     @GetMapping("/notification-preview")
     public List<NotificationPreviewDTO> getNotificationPreview(
             @AuthenticationPrincipal JwtPrincipal principal
@@ -60,6 +66,7 @@ public class MainController {
         return mainService.getNotificationPreview(userPk);
     }
 
+    @Operation(summary = "같은 달 계획 조회")
     @GetMapping("/monthly-plans")
     public List<MonthlyPlanDTO> getMonthlyPlans(
             @RequestParam int year,

--- a/src/main/java/org/solcation/solcation_be/domain/stats/StatsController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/StatsController.java
@@ -2,6 +2,7 @@ package org.solcation.solcation_be.domain.stats;
 
 import lombok.RequiredArgsConstructor;
 import org.solcation.solcation_be.domain.stats.dto.FinishTravelListDTO;
+import org.solcation.solcation_be.domain.stats.dto.TravelSpentStatsDTO;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,5 +20,15 @@ public class StatsController {
     @GetMapping("/finished-travels")
     public List<FinishTravelListDTO> getFinishedTravels(@PathVariable Long groupId) {
         return statsService.getFinishedTravels(groupId);
+    }
+
+    @GetMapping("/{travelId}/category-spent")
+    public List<TravelSpentStatsDTO> getTravelSpentCategories(@PathVariable Long groupId, @PathVariable Long travelId) {
+        return statsService.getTravelSpentStats(travelId);
+    }
+
+    @GetMapping("/{travelId}/total-spent")
+    public int getTravelTotalSpent(@PathVariable Long groupId, @PathVariable Long travelId) {
+        return statsService.getTravelTotalSpent(travelId);
     }
 }

--- a/src/main/java/org/solcation/solcation_be/domain/stats/StatsController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/StatsController.java
@@ -1,5 +1,7 @@
 package org.solcation.solcation_be.domain.stats;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.solcation.solcation_be.domain.stats.dto.FinishTravelListDTO;
 import org.solcation.solcation_be.domain.stats.dto.TravelSpentStatsDTO;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.Map;
 
+@Tag(name = "통계 컨트롤러")
 @RestController
 @RequestMapping("/groups/{groupId:\\d+}/stats")
 @RequiredArgsConstructor
@@ -18,21 +21,25 @@ public class StatsController {
 
     private final StatsService statsService;
 
+    @Operation(summary = "완료한 여행 조회")
     @GetMapping("/finished-travels")
     public List<FinishTravelListDTO> getFinishedTravels(@PathVariable Long groupId) {
         return statsService.getFinishedTravels(groupId);
     }
 
+    @Operation(summary = "특정 여행의 카테고리 별 소비 통계 조회")
     @GetMapping("/{travelId}/category-spent")
     public List<TravelSpentStatsDTO> getTravelSpentCategories(@PathVariable Long groupId, @PathVariable Long travelId) {
         return statsService.getTravelSpentStats(travelId);
     }
 
+    @Operation(summary = "특정 여행의 소비 총계 조회")
     @GetMapping("/{travelId}/total-spent")
-    public int getTravelTotalSpent(@PathVariable Long groupId, @PathVariable Long travelId) {
+    public long getTravelTotalSpent(@PathVariable Long groupId, @PathVariable Long travelId) {
         return statsService.getTravelTotalSpent(travelId);
     }
 
+    @Operation(summary = "같은 여행지의 다른 그룹과 소비 총계 비교")
     @GetMapping("/{travelId}/compare")
     public Map<String, Integer> getPerPersonPerDayCompare(@PathVariable Long groupId, @PathVariable Long travelId) {
         return statsService.getPerPersonPerDayCompare(travelId);

--- a/src/main/java/org/solcation/solcation_be/domain/stats/StatsController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/StatsController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/groups/{groupId:\\d+}/stats")
@@ -30,5 +31,10 @@ public class StatsController {
     @GetMapping("/{travelId}/total-spent")
     public int getTravelTotalSpent(@PathVariable Long groupId, @PathVariable Long travelId) {
         return statsService.getTravelTotalSpent(travelId);
+    }
+
+    @GetMapping("/{travelId}/compare")
+    public Map<String, Integer> getPerPersonPerDayCompare(@PathVariable Long groupId, @PathVariable Long travelId) {
+        return statsService.getPerPersonPerDayCompare(travelId);
     }
 }

--- a/src/main/java/org/solcation/solcation_be/domain/stats/StatsService.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/StatsService.java
@@ -7,6 +7,7 @@ import org.solcation.solcation_be.domain.stats.dto.TravelSpentStatsDTO;
 import org.solcation.solcation_be.entity.PlanDetail;
 import org.solcation.solcation_be.entity.Travel;
 import org.solcation.solcation_be.repository.PlanDetailRepository;
+import org.solcation.solcation_be.repository.GroupMemberRepository;
 import org.solcation.solcation_be.repository.TravelRepository;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,7 @@ public class StatsService {
 
     private final TravelRepository travelRepository;
     private final PlanDetailRepository planDetailRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     // 완료된 여행 목록 조회
     public List<FinishTravelListDTO> getFinishedTravels(Long groupPk) {
@@ -61,5 +63,41 @@ public class StatsService {
     public int getTravelTotalSpent(Long travelId) {
         List<PlanDetail> details = planDetailRepository.findAliveByTravelOrderByPosition(travelId);
         return details.stream().mapToInt(PlanDetail::getPdCost).sum();
+    }
+
+    // 다른 그룹과 비교
+    public Map<String, Integer> getPerPersonPerDayCompare(Long travelId) {
+        Travel t = travelRepository.findById(travelId).orElseThrow();
+        Long groupPk = t.getGroup().getGroupPk();
+
+        long members = groupMemberRepository.countByGroup_GroupPkAndIsAcceptedTrueAndIsOutFalse(groupPk);
+        long days = java.time.temporal.ChronoUnit.DAYS.between(t.getTpStart(), t.getTpEnd()) + 1;
+        int total = planDetailRepository.findAliveByTravelOrderByPosition(travelId)
+                .stream().mapToInt(PlanDetail::getPdCost).sum();
+        int our = (members == 0 || days == 0) ? 0 : (int) Math.round((double) total / members / days);
+
+        var others = travelRepository.findByTpLocationAndGroup_GroupPkNotAndTpState(
+                t.getTpLocation(),
+                groupPk,
+                TRAVELSTATE.FINISH
+        );
+
+        java.util.DoubleSummaryStatistics stats = others.stream().mapToDouble(o -> {
+            long m = groupMemberRepository.countByGroup_GroupPkAndIsAcceptedTrueAndIsOutFalse(o.getGroup().getGroupPk());
+            long d = java.time.temporal.ChronoUnit.DAYS.between(o.getTpStart(), o.getTpEnd()) + 1;
+            if (m == 0 || d == 0) return 0d;
+            int tot = planDetailRepository.findAliveByTravelOrderByPosition(o.getTpPk())
+                    .stream().mapToInt(PlanDetail::getPdCost).sum();
+            return (double) tot / m / d;
+        }).summaryStatistics();
+
+        int otherEverage = stats.getCount() == 0 ? 0 : (int) Math.round(stats.getAverage());
+        int diff = our - otherEverage;
+
+        return Map.of(
+                "ourPayPerDay", our,
+                "averagePerDay", otherEverage,
+                "difference", diff
+        );
     }
 }

--- a/src/main/java/org/solcation/solcation_be/domain/stats/StatsService.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/StatsService.java
@@ -3,18 +3,25 @@ package org.solcation.solcation_be.domain.stats;
 import lombok.RequiredArgsConstructor;
 import org.solcation.solcation_be.domain.stats.dto.FinishTravelListDTO;
 import org.solcation.solcation_be.entity.enums.TRAVELSTATE;
+import org.solcation.solcation_be.domain.stats.dto.TravelSpentStatsDTO;
+import org.solcation.solcation_be.entity.PlanDetail;
 import org.solcation.solcation_be.entity.Travel;
+import org.solcation.solcation_be.repository.PlanDetailRepository;
 import org.solcation.solcation_be.repository.TravelRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class StatsService {
 
     private final TravelRepository travelRepository;
+    private final PlanDetailRepository planDetailRepository;
 
+    // 완료된 여행 목록 조회
     public List<FinishTravelListDTO> getFinishedTravels(Long groupPk) {
         List<Travel> travels =
                 travelRepository.findByGroup_GroupPkAndTpStateOrderByTpEndDesc(groupPk, TRAVELSTATE.FINISH);
@@ -29,5 +36,30 @@ public class StatsService {
                         .tpcIcon(t.getTravelCategory().getTpcIcon())
                         .build())
                 .toList();
+    }
+
+    // 카테고리 별 합계
+    public List<TravelSpentStatsDTO> getTravelSpentStats(Long travelId) {
+
+        List<PlanDetail> details = planDetailRepository.findAliveByTravelOrderByPosition(travelId);
+
+        Map<String, Integer> byCategory = details.stream()
+                .collect(Collectors.groupingBy(
+                        d -> d.getTransactionCategory().getTcName(),
+                        Collectors.summingInt(PlanDetail::getPdCost)
+                ));
+
+        return byCategory.entrySet().stream()
+                .map(e -> TravelSpentStatsDTO.builder()
+                        .pdCost(e.getValue())
+                        .tcName(e.getKey())
+                        .build())
+                .toList();
+    }
+
+    // 소비 총계
+    public int getTravelTotalSpent(Long travelId) {
+        List<PlanDetail> details = planDetailRepository.findAliveByTravelOrderByPosition(travelId);
+        return details.stream().mapToInt(PlanDetail::getPdCost).sum();
     }
 }

--- a/src/main/java/org/solcation/solcation_be/domain/stats/StatsService.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/StatsService.java
@@ -60,9 +60,12 @@ public class StatsService {
     }
 
     // 소비 총계
-    public int getTravelTotalSpent(Long travelId) {
-        List<PlanDetail> details = planDetailRepository.findAliveByTravelOrderByPosition(travelId);
-        return details.stream().mapToInt(PlanDetail::getPdCost).sum();
+    public long getTravelTotalSpent(Long travelId) {
+        return planDetailRepository.findAliveByTravelOrderByPosition(travelId).stream()
+                .map(PlanDetail::getPdCost)
+                .filter(java.util.Objects::nonNull)
+                .mapToLong(Integer::longValue)
+                .sum();
     }
 
     // 다른 그룹과 비교

--- a/src/main/java/org/solcation/solcation_be/domain/stats/dto/SpentPerPersonDTO.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/dto/SpentPerPersonDTO.java
@@ -1,0 +1,12 @@
+package org.solcation.solcation_be.domain.stats.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SpentPerPersonDTO {
+    private int pdCost;
+    private String tcName;
+}

--- a/src/main/java/org/solcation/solcation_be/domain/stats/dto/TravelFullSpentStatsDTO.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/dto/TravelFullSpentStatsDTO.java
@@ -1,0 +1,11 @@
+package org.solcation.solcation_be.domain.stats.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TravelFullSpentStatsDTO {
+    private int pdCost;
+    private String tcName;
+}

--- a/src/main/java/org/solcation/solcation_be/domain/stats/dto/TravelSpentStatsDTO.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/dto/TravelSpentStatsDTO.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class TravelFullSpentStatsDTO {
+public class TravelSpentStatsDTO {
     private int pdCost;
     private String tcName;
 }

--- a/src/main/java/org/solcation/solcation_be/repository/GroupMemberRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/GroupMemberRepository.java
@@ -25,4 +25,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     ORDER BY g.user.userPk ASC
     """)
     List<User> findByGroup_GroupPkAndRoleAndIsAcceptedOrderByUser_UserPkAsc(@Param("groupPk") Long groupPk, @Param("role") Boolean role, @Param("isAccepted") Boolean isAccepted);
+
+    // 그룹 멤버 수
+    long countByGroup_GroupPkAndIsAcceptedTrueAndIsOutFalse(Long groupPk);
 }

--- a/src/main/java/org/solcation/solcation_be/repository/TravelRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/TravelRepository.java
@@ -1,6 +1,8 @@
 package org.solcation.solcation_be.repository;
 
 import org.solcation.solcation_be.entity.enums.TRAVELSTATE;
+import org.solcation.solcation_be.domain.stats.dto.FinishTravelListDTO;
+import org.solcation.solcation_be.entity.PlanDetail;
 import org.solcation.solcation_be.entity.Travel;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -21,4 +23,7 @@ public interface TravelRepository extends JpaRepository<Travel, Long> {
 
     // 통계 페이지 완료한 여행 렌더링
     List<Travel> findByGroup_GroupPkAndTpStateOrderByTpEndDesc(Long groupPk, TRAVELSTATE tpState);
+
+    // 우리 그룹과 같은 여행지, 우리 그룹을 제외한 다른 그룹들의 여행
+    List<Travel> findByTpLocationAndGroup_GroupPkNotAndTpState(String tpLocation, Long excludeGroupPk, TRAVELSTATE state);
 }


### PR DESCRIPTION
총계, 카테고리 별 합계, 같은 여행지를 여행 한 다른 그룹과의 인당 평균 비교 구현 했습니다
더미데이터 넣어보는게 개발보다 오래걸리네요

- 총계
<img width="473" height="161" alt="totalSpent" src="https://github.com/user-attachments/assets/14390fe5-1fe3-431b-b722-a03778514fd2" />

- 카테고리 별 합계
<img width="693" height="441" alt="categoryTotal" src="https://github.com/user-attachments/assets/f3ec9d56-9e97-4b67-b980-8f03499b6067" />

- 다른 그룹과 비교
<img width="260" height="144" alt="compare" src="https://github.com/user-attachments/assets/e0910353-e1ce-40e7-86d2-9d4ccf09b6d9" />

difference : 차이
ourPayPerDay : 우리 그룹의 1인당 1일 평균 소비량
averagePerDay : 다른 그룹의 1인당 1일평균 소비량 
