### PR TITLE
Feat: 카드 유효기간 체크 배치 추가

### DIFF
--- a/src/main/java/org/solcation/solcation_be/config/CardExpiryJobBatch.java
+++ b/src/main/java/org/solcation/solcation_be/config/CardExpiryJobBatch.java
@@ -1,0 +1,171 @@
+package org.solcation.solcation_be.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.solcation.solcation_be.scheduler.CustomJobParameterIncrementer;
+import org.solcation.solcation_be.scheduler.dto.CardExpiryDTO;
+import org.solcation.solcation_be.util.timezone.ZonedTimeUtil;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.*;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+
+import javax.sql.DataSource;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class CardExpiryJobBatch {
+    private static final String JOB_NAME = "cardExpiryJob";
+    private static final String STEP_NAME = "cardExpiryStep";
+
+    @Bean
+    public Job cardExpProcessing(JobRepository jobRepository, PlatformTransactionManager transactionManager, DataSource dataSource) {
+        log.info("[Batch-start] Batch Start");
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .incrementer(new CustomJobParameterIncrementer())
+                .start(cardExpiryStep(jobRepository, transactionManager, dataSource))
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step cardExpiryStep(JobRepository jobRepository, PlatformTransactionManager transactionManager, DataSource dataSource) {
+        DefaultTransactionAttribute attr = new DefaultTransactionAttribute(TransactionDefinition.PROPAGATION_REQUIRED); //청크를 트랜잭션 단위로 취급
+        attr.setTimeout(30); //30초 이내 트랜잭션 성공 요구
+
+        return new StepBuilder(STEP_NAME, jobRepository)
+                .<Long, CardExpiryDTO>chunk(50, transactionManager) //sac_pk -> CardExpiryDTO
+                .reader(itemReader(dataSource))
+                .processor(itemProcessor())
+
+                .writer(itemWriter(dataSource))
+
+                /* 내결함 */
+                .faultTolerant()
+
+                /* Retry */
+                .retry(PessimisticLockingFailureException.class) //retry: 교착 예외
+                .retry(CannotAcquireLockException.class) //retry: 락 획들 실패
+                .retry(QueryTimeoutException.class) //retry: 타임아웃
+                .retryLimit(3)
+                .backOffPolicy(exponentialBackoff())
+
+                /* Skip */
+                .skip(DataIntegrityViolationException.class) //skip: 제약 조건 위반
+                .skipLimit(25)
+
+                /* No Rollback */
+                .noRollback(EmptyResultDataAccessException.class) //no rollback: 0건 예외 취급 제외
+
+                /* No Retry */
+                .noRetry(EmptyResultDataAccessException.class) //no retry: 0건 예외 취급 제외
+                .transactionAttribute(attr)
+                .build();
+    }
+
+    /* reader */
+    @Bean
+    @StepScope
+    public ItemReader<Long> itemReader(DataSource dataSource) {
+        log.info("[Batch-start] ItemReader Start");
+        //파라미터 설정: KST 기준 년/월
+        Map<String, Object> params = new LinkedHashMap<>();
+
+        LocalDate ld = ZonedTimeUtil.now();
+        params.put("year", ld.getYear());
+        params.put("month", ld.getMonth().getValue());
+
+        //정렬 기준 설정(sac_pk 오름차순)
+        Map<String, Order> sort = new LinkedHashMap<>();
+        sort.put("sac_pk", Order.ASCENDING);
+
+        return new JdbcPagingItemReaderBuilder<Long>()
+                .name("cardReader")
+                .dataSource(dataSource)
+                .parameterValues(params)
+                .saveState(true)
+                .pageSize(50)
+                .rowMapper((rs, i) -> rs.getObject("sac_pk", Long.class))
+                .sortKeys(sort)
+                .selectClause("SELECT sac_pk")
+                .fromClause("FROM shared_account_card_tb")
+                .whereClause("""
+                        WHERE cancellation = false
+                        AND (
+                            expiration_year < :year
+                            OR (expiration_year = :year AND expiration_month <= :month)
+                        )
+                        """)
+                .build();
+    }
+
+    /* processor */
+    @Bean
+    @StepScope
+    public ItemProcessor<Long, CardExpiryDTO> itemProcessor() {
+        log.info("[Batch-start] ItemProcessor Start");
+        final Instant nowIns = Instant.now();
+        return pk -> {
+            log.info("[Batch-Processor] Read sac_pk = {}", pk);
+            return CardExpiryDTO.builder()
+                    .sacPk(pk)
+                    .nowIns(nowIns)
+                    .build();
+        };
+    }
+
+    /* writer */
+    @Bean
+    @StepScope
+    public JdbcBatchItemWriter<CardExpiryDTO> itemWriter(DataSource dataSource) {
+        log.info("[Batch-start] JdbcBatchItemWriter Start");
+        return new JdbcBatchItemWriterBuilder<CardExpiryDTO>()
+                .dataSource(dataSource)
+                .sql("""
+                    UPDATE shared_account_card_tb
+                    SET cancellation = true, cancellation_date = :nowIns
+                    WHERE sac_pk = :sacPk AND cancellation = false
+                    """)
+                .itemSqlParameterSourceProvider(item ->
+                    new MapSqlParameterSource()
+                            .addValue("sacPk", item.getSacPk())
+                            .addValue("nowIns", item.getNowIns())
+                )
+                .assertUpdates(false)
+                .build();
+    }
+
+    /* 재시도(Retry) 까지의 지연 시간(ms) 설정 */
+    @Bean
+    public ExponentialBackOffPolicy exponentialBackoff() {
+        var p = new ExponentialBackOffPolicy();
+        p.setInitialInterval(50);
+        p.setMultiplier(2.0);
+        p.setMaxInterval(2000);
+        return p;
+    }
+}

--- a/src/main/java/org/solcation/solcation_be/scheduler/CustomJobParameterIncrementer.java
+++ b/src/main/java/org/solcation/solcation_be/scheduler/CustomJobParameterIncrementer.java
@@ -1,0 +1,23 @@
+package org.solcation.solcation_be.scheduler;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersIncrementer;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+public class CustomJobParameterIncrementer implements JobParametersIncrementer {
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy MM.dd HH:mm:ss SSS").withZone(ZoneId.of("Asia/Seoul"));
+
+
+    @Override
+    public JobParameters getNext(JobParameters jobParameters) {
+        String id = FMT.format(Instant.now());
+
+        return new JobParametersBuilder().addString("run.id", id).toJobParameters();
+    }
+}

--- a/src/main/java/org/solcation/solcation_be/scheduler/dto/CardExpiryDTO.java
+++ b/src/main/java/org/solcation/solcation_be/scheduler/dto/CardExpiryDTO.java
@@ -1,0 +1,17 @@
+package org.solcation.solcation_be.scheduler.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardExpiryDTO {
+    private Long sacPk;
+    private Instant nowIns;
+}


### PR DESCRIPTION
카드 유효기간 체크해서 만료 여부(is_cancellation, cancellation_date) 업데이트하는 배치 구현했습니다. 

배치 메타 테이블이 다음과 같이 생성된 상태입니다. 
`BATCH_JOB_EXECUTION`
`BATCH_JOB_EXECUTION_CONTEXT`
`BATCH_JOB_EXECUTION_PARAMS`
`BATCH_JOB_EXECUTION_SEQ`
`BATCH_JOB_INSTANCE`
`BATCH_JOB_SEQ`
`BATCH_STEP_EXECUTION`
`BATCH_STEP_EXECUTION_CONTEXT`
`BATCH_STEP_EXECUTION_SEQ`

cardExpiryJob, cardExpiryStep이름으로 배치 작업이 실행됩니다. 
예외 상황은 내결함성 기능을 활성화한 후 다음과 같이 처리하도록 구현했습니다. 

1. 재시도(Retry): DB에 관한 일시적 오류들이 발생했을 때 재시도 -> 3번 재시도 
- PessimisticLockingFailureException: 교착 상태가 발생한 경우 재시도
- CannotAcquireLockException: 락 획득 실패 시 재시도
- QueryTimeoutException: 쿼리 실행 중 타임아웃 발생 시 재시도
- CannotGetJdbcConnectionException: DB 커넥션 오류 시 재시도
- DataAccessException: 자원 실패(네트워크 오류, 서버 오류 등) 시 재시도

2. 스킵(Skip): -> 25개까지만 스킵 허용
- DataIntegrityViolationException: 제약 조건 위반 시 스킵

3. 롤백 X, 재시도 X: 아래 예외 사항들은 발생 시에도 롤백 및 재시도 X
- EmptyResultDataAccessException: 업데이트 0건 시에도 예외 취급 X

배치 흐름은 다음과 같습니다.
Reader -> Processor -> Writer
1. Reader: `shared_account_card_tb` 테이블에서 현재 날짜 기준 유효기간 지난 데이터들 중 취소가 되지 않은 로우들만 sac_pk를 추출
2. Processor: sac_pk를 CardExpiryDTO(sac_pk, now)로 변환. now는 cancellation_date에 들어갈 UTC기준 현재 시각(청크마다 동일하게 처리)
3. Writer: 업데이트 

이후 다른 배치 구현 시 **주의할** 점은 다음과 같습니다.

1. incrementer는 무조건 `CustomJobParameterIncrementer` 사용 
scheduler패키지에 작성해놓았습니다. 디폴트로 구현된 incrementer 대신 KST 기준 현재 시각이 id로 찍히는 incrementer입니다. 이를 기준으로 배치 메타 테이블들이 구현되어있기 때문에 다른 incrementer사용 시 오류가 발생합니다. 
2.  application.yml에서 `batch.jdbc.initialize-schema: never`은 절대 변경하지 말아주세요. 배치 메타 테이블을 서버 실행 시 마다 생성해주는 설정인데, 이미 생성되었는지 여부를 확인하지 않아서 오류가 발생할 수 있습니다.
3. application.yml에서 `batch.job.enable: false`는 테스트 시에만 true로 바꿔서 테스트해주시고 절대 커밋에는 true로 바꿔서 올리지 말아주세요. 서버 시작 시에 배치를 실행하는 설정인데, 저희는 스케줄러를 이용해서 배치를 실행할 예정이기 때문에 불필요한 설정입니다. 