### PR TITLE
Feat: 여행 상태 업데이트 배치 구현

### DIFF
--- a/src/main/java/org/solcation/solcation_be/config/TravelStateJobBatch.java
+++ b/src/main/java/org/solcation/solcation_be/config/TravelStateJobBatch.java
@@ -1,0 +1,191 @@
+package org.solcation.solcation_be.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.solcation.solcation_be.scheduler.CustomJobParameterIncrementer;
+import org.solcation.solcation_be.scheduler.dto.TravelDTO;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+
+import javax.sql.DataSource;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class TravelStateJobBatch {
+
+    private static final String JOB_NAME  = "updateTravelStateJob";
+    private static final String STEP_NAME = "updateTravelStateStep";
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final DataSource dataSource;
+
+    /* Job */
+    @Bean
+    public Job updateTravelStateJob() {
+        log.info("[Batch-start] TravelState Job Start");
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .incrementer(new CustomJobParameterIncrementer())
+                .start(updateTravelStateStep())
+                .build();
+    }
+
+    /* Step */
+    @Bean
+    @JobScope
+    public Step updateTravelStateStep() {
+        DefaultTransactionAttribute attr = new DefaultTransactionAttribute(TransactionDefinition.PROPAGATION_REQUIRED);
+        attr.setTimeout(30);
+
+        return new StepBuilder(STEP_NAME, jobRepository)
+                .<TravelDTO, TravelDTO>chunk(1000, transactionManager)
+                .reader(itemReader(null))
+                .processor(itemProcessor(null))
+                .writer(itemWriter())
+
+                .faultTolerant()
+
+                .retry(org.springframework.dao.PessimisticLockingFailureException.class)
+                .retry(CannotAcquireLockException.class)
+                .retry(org.springframework.dao.QueryTimeoutException.class)
+                .retryLimit(3)
+                .backOffPolicy(exponentialBackoff())
+
+                .skip(DataIntegrityViolationException.class)
+                .skipLimit(25)
+
+                .noRollback(EmptyResultDataAccessException.class)
+                .noRetry(EmptyResultDataAccessException.class)
+
+                .transactionAttribute(attr)
+                .build();
+    }
+
+    /* Reader */
+    @Bean
+    @StepScope
+    public ItemReader<TravelDTO> itemReader(
+            @org.springframework.beans.factory.annotation.Value("#{jobParameters['runDate']}") String runDate
+    ) {
+        log.info("[Batch-start] TravelState Reader Start (runDate={})", runDate);
+
+        LocalDate base = (runDate != null && !runDate.isBlank())
+                ? LocalDate.parse(runDate)
+                : LocalDate.now();
+
+        Map<String, Object> params = Map.of("base", base);
+
+        // 정렬 키
+        Map<String, Order> sort = new LinkedHashMap<>();
+        sort.put("tp_pk", Order.ASCENDING);
+
+        return new JdbcPagingItemReaderBuilder<TravelDTO>()
+                .name("travelStateReader")
+                .dataSource(dataSource)
+                .parameterValues(params)
+                .saveState(true)
+                .pageSize(1000)
+                .rowMapper(new BeanPropertyRowMapper<>(TravelDTO.class))
+                .sortKeys(sort)
+                .selectClause("""
+                    SELECT
+                        tp_pk    AS pk,
+                        tp_start AS startDate,
+                        tp_end   AS endDate,
+                        tp_state AS state
+                    """)
+                .fromClause("FROM travel_plan_tb")
+                .whereClause("""
+                    WHERE
+                        (tp_end   < :base AND tp_state <> 2) /* FINISH 후보 */
+                     OR (tp_start <= :base AND tp_end >= :base AND tp_state <> 1) /* ONGOING 후보 */
+                     OR (tp_start  > :base AND tp_state <> 0) /* BEFORE 후보 */
+                    """)
+                .build();
+    }
+
+    /* Processor */
+    @Bean
+    @StepScope
+    public ItemProcessor<TravelDTO, TravelDTO> itemProcessor(
+            @org.springframework.beans.factory.annotation.Value("#{jobParameters['runDate']}") String runDate
+    ) {
+        log.info("[Batch-start] TravelState Processor Start (runDate={})", runDate);
+
+        LocalDate base = (runDate != null && !runDate.isBlank())
+                ? LocalDate.parse(runDate)
+                : LocalDate.now();
+
+        return item -> {
+            int newState;
+            if (item.getEndDate().isBefore(base)) {
+                newState = 2; // FINISH
+            } else if (item.getStartDate().isAfter(base)) {
+                newState = 0; // BEFORE
+            } else {
+                newState = 1; // ONGOING
+            }
+
+            Integer cur = item.getState();
+            if (!Objects.equals(cur, newState)) {
+                item.setState(newState);
+                log.info("[Batch-Processor] pk={} state {} -> {}", item.getPk(), cur, newState);
+                return item; // 변경건만 전달
+            }
+            return null; // 미변경 시 필터링
+        };
+    }
+
+    /* Writer */
+    @Bean
+    @StepScope
+    public JdbcBatchItemWriter<TravelDTO> itemWriter() {
+        log.info("[Batch-start] TravelState Writer Start");
+        return new JdbcBatchItemWriterBuilder<TravelDTO>()
+                .dataSource(dataSource)
+                .sql("""
+                    UPDATE travel_plan_tb
+                       SET tp_state = :state
+                     WHERE tp_pk   = :pk
+                    """)
+                .itemSqlParameterSourceProvider(new org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider<>())
+                .assertUpdates(false)
+                .build();
+    }
+
+    /* Exponential Backoff (Retry 간 지연) */
+    @Bean
+    public ExponentialBackOffPolicy exponentialBackoff() {
+        var p = new ExponentialBackOffPolicy();
+        p.setInitialInterval(50);
+        p.setMultiplier(2.0);
+        p.setMaxInterval(2000);
+        return p;
+    }
+}

--- a/src/main/java/org/solcation/solcation_be/scheduler/dto/TravelDTO.java
+++ b/src/main/java/org/solcation/solcation_be/scheduler/dto/TravelDTO.java
@@ -1,0 +1,26 @@
+package org.solcation.solcation_be.scheduler.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.solcation.solcation_be.entity.enums.TRAVELSTATE;
+
+import java.time.LocalDate;
+
+@Schema(name = "여행계획 DTO")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TravelDTO {
+    private Long pk;
+    private String title;
+    private String location;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String thumbnail;
+    private Integer state;
+    private Long categoryId;
+    private String categoryName;
+    private int participant;
+}


### PR DESCRIPTION
1) Job / Step
JOB_NAME = updateTravelStateJob
STEP_NAME = updateTravelStateStep
Job CustomJobParameterIncrementer() 사용
Step은 청크 기반: 1000개 단위로 트랜잭션 처리

2) 트랜잭션 & 내결함성
DefaultTransactionAttribute + attr.setTimeout(30) → 청크 트랜잭션이 30초 제한
Retry(최대 3회 + 지수 백오프): 비관적 락 실패, 락 획득 실패, 쿼리 타임아웃
Skip(최대 25건): 무결성 제약 위반
NoRollback/NoRetry: EmptyResultDataAccessException (0건 같은 케이스는 실패로 보지 않음)
ExponentialBackOffPolicy(초기 50ms, x2, 최대 2s) 설정

3) Reader (조회)
기준일: runDate, 없으면 LocalDate.now()
JdbcPagingItemReaderBuilder 사용, 페이징 + 정렬(tp_pk ASC)
saveState(true) → 잡 재시작 시 ExecutionContext에 진행상황 저장된 곳에서부터

4) Processor (상태 재계산)
기준일 재계산(Reader와 동일 로직)
기존 state와 다른 경우에만 item 반환 → Writer로 전달
같으면 null 반환 → 필터링되어 DB 업데이트 생략

5) Writer (업데이트)]
BeanPropertyItemSqlParameterSourceProvider 사용 → TravelDTO의 getState(), getPk() 값 자동 바인딩
.assertUpdates(false) → 업데이트 건수가 0이어도 예외로 간주하지 않음(낙관적 처리)

6) Backoff
재시도 간 지연을 지수적으로 늘려 스파이크/잠깐의 락 경합에 안전

시간대 처리 잘 된거 맞는지 확인 부탁드립니다 ......