### PR TITLE
Fix: 응답 처리 수정

### DIFF
--- a/src/main/java/org/solcation/solcation_be/common/ApiResponseAdvice.java
+++ b/src/main/java/org/solcation/solcation_be/common/ApiResponseAdvice.java
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
@@ -23,6 +24,25 @@ public class ApiResponseAdvice implements ResponseBodyAdvice<Object> {
                                   Class<? extends HttpMessageConverter<?>> converterType,
                                   ServerHttpRequest request,
                                   ServerHttpResponse response) {
+
+        if(body == null) {
+            HttpStatus current = HttpStatus.OK;
+
+            //상태 코드 추출 (null을 전송하는 경우)
+            if(response instanceof ServletServerHttpResponse servlet) {
+                HttpStatus resoleved = HttpStatus.resolve(servlet.getServletResponse().getStatus());
+
+                if(resoleved != null) {
+                    current = resoleved;
+                }
+            }
+
+            if(current == HttpStatus.NO_CONTENT) {
+                return null;
+            }
+
+            return ApiResponse.ok(null);
+        }
 
         if (body instanceof ApiResponse) {
             HttpStatus status = ((ApiResponse<?>) body).httpStatus();

--- a/src/main/java/org/solcation/solcation_be/domain/notification/NotificationService.java
+++ b/src/main/java/org/solcation/solcation_be/domain/notification/NotificationService.java
@@ -89,6 +89,7 @@ public class NotificationService {
                 .pnTime(i.getPnTime())
                 .acDest(i.getAcPk().getAcDest())
                 .content(i.getPnContent())
+                .groupPk(i.getGroupPk().getGroupPk())
                 .groupName(i.getGroupPk().getGroupName())
                 .groupImage(i.getGroupPk().getGroupImage())
                 .isAccepted(i.getIsAccepted())

--- a/src/main/java/org/solcation/solcation_be/domain/notification/dto/PushNotificationDTO.java
+++ b/src/main/java/org/solcation/solcation_be/domain/notification/dto/PushNotificationDTO.java
@@ -31,6 +31,9 @@ public class PushNotificationDTO {
     private String acDest;
 
     @NotNull
+    private Long groupPk;
+
+    @NotNull
     private String groupName;
 
     @NotNull

--- a/src/main/java/org/solcation/solcation_be/repository/PushNotificationRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/PushNotificationRepository.java
@@ -36,7 +36,7 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
     @Query("""
     select new org.solcation.solcation_be.domain.notification.dto.PushNotificationDTO(
       p.pnPk, p.pnTitle, p.pnTime, p.pnContent,
-      ac.acDest, g.groupName, g.groupImage,
+      ac.acDest, g.groupPk, g.groupName, g.groupImage,
       p.isAccepted, p.readAt
     )
     from PushNotification p


### PR DESCRIPTION
- 요청 처리 후 응답이 없을 때 (void일 때) 프론트 상에서는 응답이 없는데 json으로 파싱하려고 하니까 오류가 발생했습니다. 따라서 반환할 값이 없을 때에도 success 응답을 보내도록 수정했습니다.
- 알림 조회 시 pnPk도 같이 전송하도록 수정했습니다. 