### PR TITLE
Feat:여행 전체 통계 페이지 개발

### DIFF
--- a/src/main/java/org/solcation/solcation_be/domain/stats/StatsController.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/StatsController.java
@@ -65,4 +65,9 @@ public class StatsController {
         return statsService.generateTravelInsight(travelId);
     }
 
+    @GetMapping("/plan_total")
+    public ResponseEntity<GroupTravelStatsDTO> getGroupStats(@PathVariable Long groupId) {
+        return ResponseEntity.ok(statsService.getGroupStats(groupId));
+    }
+
 }

--- a/src/main/java/org/solcation/solcation_be/domain/stats/dto/GroupTravelStatsDTO.java
+++ b/src/main/java/org/solcation/solcation_be/domain/stats/dto/GroupTravelStatsDTO.java
@@ -1,0 +1,44 @@
+package org.solcation.solcation_be.domain.stats.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GroupTravelStatsDTO {
+    private long totalTrips;                  // 총 여행 횟수
+    private long totalTripDays;               // 총 여행 기간(일수 합)
+    private long totalSpent;                  // 총 지출 금액
+    private List<CategoryShare> categoryShares; // 카테고리 비중 (파이차트용)
+    private List<CategoryAmount> top3Categories; // 가장 지출이 많은 Top3
+    private CategoryAmount leastCategory;       // 가장 적게 쓴 카테고리
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CategoryShare {
+        private Long tcPk;
+        private String name;
+        private String code;
+        private long amount;
+        private double ratio; // 전체 대비 %
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CategoryAmount {
+        private Long tcPk;
+        private String name;
+        private String code;
+        private long amount;
+    }
+}

--- a/src/main/java/org/solcation/solcation_be/repository/TransactionRepository.java
+++ b/src/main/java/org/solcation/solcation_be/repository/TransactionRepository.java
@@ -175,4 +175,76 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long>,
 
     //pk + group으로 조회
     boolean existsBySatPkAndGmPk_Group_GroupPk(@Param("satPk") Long satPk, @Param("groupPk") Long groupPk);
+
+    // 그룹의 총 여행 횟수
+    @Query("""
+            select count(tr)
+            from Travel tr
+            where tr.group.groupPk = :groupPk
+                        and tr.tpState = org.solcation.solcation_be.entity.enums.TRAVELSTATE.FINISH
+            """)
+    long countTripsByGroup(@Param("groupPk") Long groupPk);
+
+    // 그룹의 총 여행 일수 합계
+    @Query("""
+    select coalesce(
+        sum( cast(function('datediff', tr.tpEnd, tr.tpStart) as long) + 1L ),
+        0L
+    )
+    from Travel tr
+    where tr.group.groupPk = :groupPk
+      and tr.tpState = org.solcation.solcation_be.entity.enums.TRAVELSTATE.FINISH
+    """)
+    long sumTripDaysByGroup(@Param("groupPk") Long groupPk);
+
+    // 그룹의 여행 기간 동안 실제 지출 합계
+    @Query("""
+            select coalesce(sum(
+                case
+                    when t.transactionType in (
+                         org.solcation.solcation_be.entity.enums.TRANSACTIONTYPE.WITHDRAW,
+                         org.solcation.solcation_be.entity.enums.TRANSACTIONTYPE.CARD
+                    )
+                    and exists (
+                        select 1 from Travel tr
+                        where tr.group.groupPk = :groupPk
+                          and function('date', function('convert_tz', t.satTime, '+00:00', '+09:00'))
+                              between tr.tpStart and tr.tpEnd
+                    )
+                    then t.satAmount
+                    else 0
+                end
+            ), 0)
+            from Transaction t
+            where t.saPk.group.groupPk = :groupPk
+            """)
+    long sumSpentOnTravelDays(@Param("groupPk") Long groupPk);
+
+    // 그룹의 여행 기간 동안 카테고리별 합계
+    @Query("""
+            select tc.tcPk,
+                   tc.tcName,
+                   tc.tcCode,
+                   coalesce(sum(
+                       case
+                           when t.transactionType in (
+                                org.solcation.solcation_be.entity.enums.TRANSACTIONTYPE.WITHDRAW,
+                                org.solcation.solcation_be.entity.enums.TRANSACTIONTYPE.CARD
+                           )
+                           and exists (
+                               select 1 from Travel tr
+                               where tr.group.groupPk = :groupPk
+                                 and function('date', function('convert_tz', t.satTime, '+00:00', '+09:00'))
+                                     between tr.tpStart and tr.tpEnd
+                           )
+                           then t.satAmount
+                           else 0
+                       end
+                   ), 0)
+            from TransactionCategory tc
+            left join Transaction t on t.tcPk = tc
+            group by tc.tcPk, tc.tcName, tc.tcCode
+            order by tc.tcPk
+            """)
+    List<Object[]> categoryAmountsOnTravelDays(@Param("groupPk") Long groupPk);
 }


### PR DESCRIPTION
그룹 단위 여행 횟수, 총 일수, 여행일 동안 지출액, 카테고리별 합계 쿼리 추가했습니다
카테고리별 비율 계산해서 차트 생성 시 이용했습니다

그룹 단위로 여행 횟수/일수/총 소비/카테고리 분포를 한 번에 확인 가능합니다

수정 사항 코멘트 남겨주세면 확인 후 수정하겠습니다